### PR TITLE
Fixing monospaced font sizing

### DIFF
--- a/reset.css
+++ b/reset.css
@@ -157,6 +157,7 @@ sub {
 
 pre, code, kbd, samp, var {
   font-family: monospace, sans-serif;
+  font-size: 0.8em;
   cursor: text;
 }
 


### PR DESCRIPTION
When it has a `sans-serif` fallback, it boosts the files size unexpectedly in Chrome (other, not sure). Set to 0.8em.